### PR TITLE
Fix issue with `fast-deep-equal` when used with Vite

### DIFF
--- a/packages/tree-changes-hook/src/index.ts
+++ b/packages/tree-changes-hook/src/index.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import * as equal from 'fast-deep-equal';
+import equal from 'fast-deep-equal';
 import treeChanges, { Data, KeyType, TreeChanges } from 'tree-changes';
 
 export default function useTreeChanges<T extends Data>(value: T) {

--- a/packages/tree-changes-hook/tsconfig.json
+++ b/packages/tree-changes-hook/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@gilbarbara/tsconfig",
   "compilerOptions": {
     "outDir": "./lib",
-    "target": "es5"
+    "target": "es5",
+    "esModuleInterop": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts"]

--- a/packages/tree-changes/src/helpers.ts
+++ b/packages/tree-changes/src/helpers.ts
@@ -1,4 +1,4 @@
-import * as equal from 'fast-deep-equal';
+import equal from 'fast-deep-equal';
 import is from 'is-lite';
 
 import { CompareValuesOptions, Data, Key, Options, ValidTypes, Value } from './types';

--- a/packages/tree-changes/src/index.ts
+++ b/packages/tree-changes/src/index.ts
@@ -1,4 +1,4 @@
-import * as equal from 'fast-deep-equal';
+import equal from 'fast-deep-equal';
 import is from 'is-lite';
 
 import { compareNumbers, compareValues, getIterables, includesOrEqualsTo, nested } from './helpers';

--- a/packages/tree-changes/tsconfig.json
+++ b/packages/tree-changes/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@gilbarbara/tsconfig",
   "compilerOptions": {
     "outDir": "./lib",
-    "target": "es5"
+    "target": "es5",
+    "esModuleInterop": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts"]


### PR DESCRIPTION
When running this library from Vite, because it is ESM-only it will throw when trying to call `equal` from the `fast-deep-equal` library.

I believe this has to do with how it is imported, so we change the `import * as equal from...` to `import equal from...` and allow `esModuleInterop` in the `.tsconfig`

The output of this now works in a vite environment, and solves issue:
https://github.com/gilbarbara/react-joyride/issues/769