### PR TITLE
Replace fast-deep-equal with fast-deep-equal/react

### DIFF
--- a/packages/tree-changes-hook/src/index.ts
+++ b/packages/tree-changes-hook/src/index.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import * as equal from 'fast-deep-equal';
+import * as equal from 'fast-deep-equal/react';
 import treeChanges, { Data, KeyType, TreeChanges } from 'tree-changes';
 
 export default function useTreeChanges<T extends Data>(value: T) {


### PR DESCRIPTION
# Summary

Replace `fast-deep-equal` with `fast-deep-equal/react` in `packages/tree-changes-hook/src/index.ts`.

Implementation in `packages/tree-changes/src/index.ts` remain unchanged.

# Related issue

To address issue highlighted in https://github.com/gilbarbara/react-floater/issues/84


# How is this tested?

This change prevents the properties of React Fibre from being compared. 
We have tested this change on our own project by modifying the code directly in our node_modules. 